### PR TITLE
Fix cache clearing for the hash cache

### DIFF
--- a/src/Resources/config/cache.xml
+++ b/src/Resources/config/cache.xml
@@ -32,6 +32,8 @@
             <argument />
         </service>
 
-        <service id="cache.incenteev_hashed_asset" parent="cache.system" public="false" />
+        <service id="cache.incenteev_hashed_asset" parent="cache.system" public="false">
+            <tag name="cache.pool" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
In non-debug mode, hashes are cached. But the missing tag on the cache pool means that the service was not properly hooked into the Symfony cache clearing system.